### PR TITLE
Fix seeding code between runs

### DIFF
--- a/test_agent.py
+++ b/test_agent.py
@@ -50,12 +50,13 @@ def play(agent, opt, random_action=False):
 
     for no_episode in (range(opt.nepisodes)):
         if not random_action:
-            random.seed(no_episode)
-            np.random.seed(no_episode)
-            torch.manual_seed(no_episode)
+            seed = opt.seed + no_episode
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
             if torch.cuda.is_available():
-                torch.cuda.manual_seed(no_episode)
-            env.seed(no_episode)
+                torch.cuda.manual_seed(seed)
+            env.seed(seed)
 
         agent.start_episode(opt.batch_size)
         avg_eps_moves, avg_eps_scores, avg_eps_norm_scores = [], [], []

--- a/train_agent.py
+++ b/train_agent.py
@@ -50,12 +50,13 @@ def play(agent, opt, random_action=False):
 
     for no_episode in (range(opt.nepisodes)):
         if not random_action:
-            random.seed(no_episode)
-            np.random.seed(no_episode)
-            torch.manual_seed(no_episode)
+            seed = opt.seed + no_episode
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
             if torch.cuda.is_available():
-                torch.cuda.manual_seed(no_episode)
-            env.seed(no_episode)
+                torch.cuda.manual_seed(seed)
+            env.seed(seed)
 
         agent.start_episode(opt.batch_size)
         avg_eps_moves, avg_eps_scores, avg_eps_norm_scores = [], [], []


### PR DESCRIPTION
The seeding code currently doesn't take the `opt.seed` into account, so between separate runs, each episode has the same seed (run 1 episode 1 has the same seed as run 2 episode 1). This makes evaluation results much more sensitive to the random seed.